### PR TITLE
Remove loss_masking

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -313,7 +313,7 @@ class ActionValueDataset(Dataset):
 
         state = tokenize(fen).astype(np.int32)
         action = np.asarray([MOVE_TO_ACTION[move]], dtype=np.int32)
-        return_bucket = _process_win_prob(win_prob, self._return_buckets_edges)
+        return_bucket = _process_win_prob(win_prob, self._return_buckets_edges)[0]
 
         sequence = np.concatenate([state, action])
 

--- a/train.py
+++ b/train.py
@@ -83,7 +83,6 @@ for sequence, return_bucket in tqdm(train_loader):
     # currently the computed  "target logits" are taken from the computed output of the action input
     value_logits = output[:, -2, :]
     # we only care about the value logits
-    return_bucket = torch.flatten(return_bucket)
 
     loss = F.cross_entropy(value_logits, return_bucket)
 


### PR DESCRIPTION
This is a simple implementation to remove the loss_masking both in the dataset and the training loop. It will hopefully slightly speed up our training steps